### PR TITLE
Fix invalid repository error output

### DIFF
--- a/bin/gitits
+++ b/bin/gitits
@@ -54,7 +54,7 @@ fi
 pushd $repo > /dev/null
 
 if ! git status > /dev/null 2>&1; then
-  echo "$REPO is not a git repository"
+  echo "$repo is not a git repository"
   exit 1
 fi
 

--- a/test/test_gitits
+++ b/test/test_gitits
@@ -23,3 +23,10 @@ assert_equal "gitits -s -b $second -r $second -m renato $repo_path" "renato 1 1 
 expected="aeliton 62 0 62
 renato 1 1 0"
 assert_equal "gitits -s -r $second $repo_path" "$expected"
+
+# invalid git repo
+invalid_repo_path=$(mktemp -d)
+expected="$invalid_repo_path is not a git repository"
+assert_equal "gitits $invalid_repo_path" "$expected"
+assert_equal "gitits -s $invalid_repo_path" "$expected"
+rmdir "$invalid_repo_path"


### PR DESCRIPTION
Fix repository path in the output message when it is not a valid git repo and add a unit test for this case.